### PR TITLE
Adapt for use with Nitro stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/modules.xml
 .idea/vcs.xml
 .idea/workspace.xml
+.idea/cuckoocache.iml

--- a/evaluation/evaluation_test.go
+++ b/evaluation/evaluation_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestEvaluation(t *testing.T) {
-	on, local, _, _ := EvaluateOnData(32, 64, []cacheKeys.Uint64LocalCacheKey{})
+	on, local, _, _, err := EvaluateOnData(32, 64, []cacheKeys.Uint64LocalCacheKey{})
+	assert.Nil(t, err)
 	assert.Equal(t, on, uint64(0))
 	assert.Equal(t, local, uint64(0))
 
@@ -18,7 +19,8 @@ func TestEvaluation(t *testing.T) {
 	for i := 0; i < 571; i++ {
 		accesses = append(accesses, cacheKeys.NewUint64LocalCacheKey(uint64(i)))
 	}
-	on, local, _, _ = EvaluateOnData(32, 64, accesses)
+	on, local, _, _, err = EvaluateOnData(32, 64, accesses)
+	assert.Nil(t, err)
 	assert.Equal(t, on, uint64(0))
 	assert.Equal(t, local, uint64(0))
 
@@ -28,7 +30,8 @@ func TestEvaluation(t *testing.T) {
 	}
 	accesses = append(tempAccesses, tempAccesses...)
 	accesses = append(accesses, tempAccesses...)
-	on, local, _, _ = EvaluateOnData(32, 64, accesses)
+	on, local, _, _, err = EvaluateOnData(32, 64, accesses)
+	assert.Nil(t, err)
 	assert.Equal(t, on, uint64(32))
 	assert.Equal(t, local, uint64(32))
 
@@ -38,7 +41,8 @@ func TestEvaluation(t *testing.T) {
 	}
 	accesses = append(tempAccesses, tempAccesses...)
 	accesses = append(accesses, tempAccesses...)
-	on, local, _, _ = EvaluateOnData(32, 64, accesses)
+	on, local, _, _, err = EvaluateOnData(32, 64, accesses)
+	assert.Nil(t, err)
 	assert.Equal(t, on, uint64(50))
 	assert.Equal(t, local, uint64(64))
 }

--- a/onChainIndex/cuckoo_onchain_test.go
+++ b/onChainIndex/cuckoo_onchain_test.go
@@ -15,39 +15,56 @@ func TestCuckooOnChain(t *testing.T) {
 	capacity := uint64(32)
 	storage := onChainStorage.NewMockOnChainStorage()
 	cache := OpenOnChainCuckooTable(storage, capacity)
-	cache.Initialize(capacity)
-	header := cache.ReadHeader()
-	assert.Equal(t, cache.IsInCache(&header, keyFromUint64(0)), false) // verify that uninitialized table items aren't false positives
-	assert.Equal(t, cache.IsInCache(&header, keyFromUint64(31)), false)
+	assert.Nil(t, cache.Initialize(capacity))
+	header, err := cache.ReadHeader()
+	assert.Nil(t, err)
+	in, err := cache.IsInCache(&header, keyFromUint64(0))
+	assert.Nil(t, err)
+	assert.Equal(t, in, false) // verify that uninitialized table items aren't false positives
+	in, err = cache.IsInCache(&header, keyFromUint64(31))
+	assert.Nil(t, err)
+	assert.Equal(t, in, false)
 	verifyAccurateGenerationCounts(t, cache)
 
 	// make cache almost full and verify items are in cache
 	for i := uint64(0); i < capacity-2; i++ {
-		cache.AccessItem(keyFromUint64(i))
+		_, _, err = cache.AccessItem(keyFromUint64(i))
+		assert.Nil(t, err)
 		verifyAccurateGenerationCounts(t, cache)
-		assert.Equal(t, countCachedItems(cache), i+1)
+		count, err := countCachedItems(cache)
+		assert.Nil(t, err)
+		assert.Equal(t, count, i+1)
 	}
 	cache = OpenOnChainCuckooTable(storage, capacity)
 	for i := uint64(0); i < capacity-2; i++ {
-		header := cache.ReadHeader()
-		assert.Equal(t, cache.IsInCache(&header, keyFromUint64(i)), true)
+		header, err := cache.ReadHeader()
+		assert.Nil(t, err)
+		in, err = cache.IsInCache(&header, keyFromUint64(i))
+		assert.Nil(t, err)
+		assert.Equal(t, in, true)
 		verifyAccurateGenerationCounts(t, cache)
 	}
 	cache = OpenOnChainCuckooTable(storage, capacity)
-	assert.Equal(t, cache.ReadHeader().InCacheCount, capacity-2)
+	header, err = cache.ReadHeader()
+	assert.Nil(t, err)
+	assert.Equal(t, header.InCacheCount, capacity-2)
 	verifyAccurateGenerationCounts(t, cache)
 
 	// add items beyond capacity and verify that something was evicted
 	for i := capacity - 2; i < capacity+1; i++ {
 		cache = OpenOnChainCuckooTable(storage, capacity)
-		cache.AccessItem(keyFromUint64(i))
+		_, _, err = cache.AccessItem(keyFromUint64(i))
+		assert.Nil(t, err)
 		verifyAccurateGenerationCounts(t, cache)
 	}
 	foundThemAll := true
 	for i := uint64(0); i < capacity+1; i++ {
 		cache = OpenOnChainCuckooTable(storage, capacity)
-		header := cache.ReadHeader()
-		if !cache.IsInCache(&header, keyFromUint64(i)) {
+		header, err := cache.ReadHeader()
+		assert.Nil(t, err)
+		in, err = cache.IsInCache(&header, keyFromUint64(i))
+		assert.Nil(t, err)
+		if !in {
 			foundThemAll = false
 		}
 	}
@@ -55,33 +72,49 @@ func TestCuckooOnChain(t *testing.T) {
 	verifyAccurateGenerationCounts(t, cache)
 
 	cache = OpenOnChainCuckooTable(storage, capacity)
-	sprayOnChainCache(cache, 98113084)
+	assert.Nil(t, sprayOnChainCache(cache, 98113084))
 	cache = OpenOnChainCuckooTable(storage, capacity)
 	verifyAccurateGenerationCounts(t, cache)
-	cache.AccessItem(keyFromUint64(58712))
+	_, _, err = cache.AccessItem(keyFromUint64(58712))
+	assert.Nil(t, err)
 	cache = OpenOnChainCuckooTable(storage, capacity)
-	header = cache.ReadHeader()
-	assert.Equal(t, cache.IsInCache(&header, keyFromUint64(58712)), true)
+	header, err = cache.ReadHeader()
+	assert.Nil(t, err)
+	in, err = cache.IsInCache(&header, keyFromUint64(58712))
+	assert.Nil(t, err)
+	assert.Equal(t, in, true)
 }
 
 func TestOnChainFlush(t *testing.T) {
 	capacity := uint64(32)
 	storage := onChainStorage.NewMockOnChainStorage()
 	cache := OpenOnChainCuckooTable(storage, capacity)
-	cache.Initialize(capacity)
+	assert.Nil(t, cache.Initialize(capacity))
 
-	sprayOnChainCache(cache, 98113084)
-	cache.AccessItem(keyFromUint64(42))
-	header := cache.ReadHeader()
-	assert.Equal(t, cache.IsInCache(&header, keyFromUint64(42)), true)
-	cache.FlushOneItem(keyFromUint64(42))
-	assert.Equal(t, cache.IsInCache(&header, keyFromUint64(42)), false)
+	assert.Nil(t, sprayOnChainCache(cache, 98113084))
+	_, _, err := cache.AccessItem(keyFromUint64(42))
+	assert.Nil(t, err)
+	header, err := cache.ReadHeader()
+	assert.Nil(t, err)
+	in, err := cache.IsInCache(&header, keyFromUint64(42))
+	assert.Nil(t, err)
+	assert.Equal(t, in, true)
+	assert.Nil(t, cache.FlushOneItem(keyFromUint64(42)))
+	in, err = cache.IsInCache(&header, keyFromUint64(42))
+	assert.Nil(t, err)
+	assert.Equal(t, in, false)
 
-	cache.AccessItem(keyFromUint64(42))
-	cache.FlushAll()
-	header = cache.ReadHeader()
-	assert.Equal(t, cache.IsInCache(&header, keyFromUint64(42)), false)
-	assert.Equal(t, cache.ReadHeader().InCacheCount, uint64(0))
+	_, _, err = cache.AccessItem(keyFromUint64(42))
+	assert.Nil(t, err)
+	assert.Nil(t, cache.FlushAll())
+	header, err = cache.ReadHeader()
+	assert.Nil(t, err)
+	in, err = cache.IsInCache(&header, keyFromUint64(42))
+	assert.Nil(t, err)
+	assert.Equal(t, in, false)
+	header, err = cache.ReadHeader()
+	assert.Nil(t, err)
+	assert.Equal(t, header.InCacheCount, uint64(0))
 }
 
 func keyFromUint64(key uint64) CacheItemKey {
@@ -91,20 +124,27 @@ func keyFromUint64(key uint64) CacheItemKey {
 	return ret
 }
 
-func sprayOnChainCache(cache *OnChainCuckooTable, seed uint64) {
-	capacity := cache.ReadHeader().Capacity
+func sprayOnChainCache(cache *OnChainCuckooTable, seed uint64) error {
+	header, err := cache.ReadHeader()
+	if err != nil {
+		return err
+	}
+	capacity := header.Capacity
 	modulus := 11 * capacity / 7
 	for i := uint64(seed); i < seed+capacity; i++ {
 		item := seed + (i % modulus)
-		cache.AccessItem(keyFromUint64(item))
+		if _, _, err = cache.AccessItem(keyFromUint64(item)); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func countCachedItems(cache *OnChainCuckooTable) uint64 {
+func countCachedItems(cache *OnChainCuckooTable) (uint64, error) {
 	return ForAllOnChainCachedItems(
 		cache,
-		func(_ CacheItemKey, _ bool, numSoFar uint64) uint64 {
-			return numSoFar + 1
+		func(_ CacheItemKey, _ bool, numSoFar uint64) (uint64, error) {
+			return numSoFar + 1, nil
 		},
 		0,
 	)
@@ -112,25 +152,28 @@ func countCachedItems(cache *OnChainCuckooTable) uint64 {
 
 func verifyAccurateGenerationCounts(t *testing.T, cache *OnChainCuckooTable) {
 	t.Helper()
-	header := cache.ReadHeader()
-	manualLastGenCount := ForAllOnChainCachedItems[uint64](
+	header, err := cache.ReadHeader()
+	assert.Nil(t, err)
+	manualLastGenCount, err := ForAllOnChainCachedItems[uint64](
 		cache,
-		func(key CacheItemKey, inLatestGeneration bool, soFar uint64) uint64 {
+		func(key CacheItemKey, inLatestGeneration bool, soFar uint64) (uint64, error) {
 			if inLatestGeneration {
-				return soFar + 1
+				return soFar + 1, nil
 			} else {
-				return soFar
+				return soFar, nil
 			}
 		},
 		0,
 	)
+	assert.Nil(t, err)
 	assert.Equal(t, manualLastGenCount, header.CurrentGenCount)
-	manualBothGensCount := ForAllOnChainCachedItems[uint64](
+	manualBothGensCount, err := ForAllOnChainCachedItems[uint64](
 		cache,
-		func(key CacheItemKey, inLatestGeneration bool, soFar uint64) uint64 {
-			return soFar + 1
+		func(key CacheItemKey, inLatestGeneration bool, soFar uint64) (uint64, error) {
+			return soFar + 1, nil
 		},
 		0,
 	)
+	assert.Nil(t, err)
 	assert.Equal(t, manualBothGensCount, header.InCacheCount)
 }

--- a/onChainIndex/storage_backed_test.go
+++ b/onChainIndex/storage_backed_test.go
@@ -15,7 +15,7 @@ func TestStorageBacked(t *testing.T) {
 	sb := OpenOnChainCuckooTable(storage, capacity)
 
 	// everything should be empty to start
-	citem, err := sb.ReadTableEntry(3, 17)
+	citem, err := sb.ReadTableEntry(17, 3)
 	assert.Nil(t, err)
 	assert.Equal(t, citem.ItemKey, [24]byte{})
 	assert.Equal(t, citem.Generation, uint64(0))
@@ -53,14 +53,14 @@ func TestStorageBacked(t *testing.T) {
 		ItemKey:    keyFromUint64(39),
 		Generation: 39,
 	}
-	assert.Nil(t, sb.WriteTableEntry(3, 9, item39))
+	assert.Nil(t, sb.WriteTableEntry(9, 3, item39))
 	header, err = sb.ReadHeader()
 	assert.Nil(t, err)
 	assert.Equal(t, header, myHeader)
 	entry, err = sb.ReadTableEntry(0, 0)
 	assert.Nil(t, err)
 	assert.Equal(t, entry, item00)
-	entry, err = sb.ReadTableEntry(3, 9)
+	entry, err = sb.ReadTableEntry(9, 3)
 	assert.Nil(t, err)
 	assert.Equal(t, entry, item39)
 }

--- a/onChainIndex/storage_backed_test.go
+++ b/onChainIndex/storage_backed_test.go
@@ -15,10 +15,12 @@ func TestStorageBacked(t *testing.T) {
 	sb := OpenOnChainCuckooTable(storage, capacity)
 
 	// everything should be empty to start
-	citem := sb.ReadTableEntry(3, 17)
+	citem, err := sb.ReadTableEntry(3, 17)
+	assert.Nil(t, err)
 	assert.Equal(t, citem.ItemKey, [24]byte{})
 	assert.Equal(t, citem.Generation, uint64(0))
-	header := sb.ReadHeader()
+	header, err := sb.ReadHeader()
+	assert.Nil(t, err)
 	assert.Equal(t, header.InCacheCount, uint64(0))
 	assert.Equal(t, header.Capacity, uint64(0))
 	assert.Equal(t, header.CurrentGenCount, uint64(0))
@@ -30,23 +32,35 @@ func TestStorageBacked(t *testing.T) {
 		CurrentGenCount:   106,
 		InCacheCount:      3,
 	}
-	sb.WriteHeader(myHeader)
-	assert.Equal(t, sb.ReadHeader(), myHeader)
+	assert.Nil(t, sb.WriteHeader(myHeader))
+	header, err = sb.ReadHeader()
+	assert.Nil(t, err)
+	assert.Equal(t, header, myHeader)
 
 	item00 := CuckooItem{
 		ItemKey:    keyFromUint64(13),
 		Generation: 13,
 	}
-	sb.WriteTableEntry(0, 0, item00)
-	assert.Equal(t, sb.ReadHeader(), myHeader)
-	assert.Equal(t, sb.ReadTableEntry(0, 0), item00)
+	assert.Nil(t, sb.WriteTableEntry(0, 0, item00))
+	header, err = sb.ReadHeader()
+	assert.Nil(t, err)
+	assert.Equal(t, header, myHeader)
+	entry, err := sb.ReadTableEntry(0, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, entry, item00)
 
 	item39 := CuckooItem{
 		ItemKey:    keyFromUint64(39),
 		Generation: 39,
 	}
-	sb.WriteTableEntry(3, 9, item39)
-	assert.Equal(t, sb.ReadHeader(), myHeader)
-	assert.Equal(t, sb.ReadTableEntry(0, 0), item00)
-	assert.Equal(t, sb.ReadTableEntry(3, 9), item39)
+	assert.Nil(t, sb.WriteTableEntry(3, 9, item39))
+	header, err = sb.ReadHeader()
+	assert.Nil(t, err)
+	assert.Equal(t, header, myHeader)
+	entry, err = sb.ReadTableEntry(0, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, entry, item00)
+	entry, err = sb.ReadTableEntry(3, 9)
+	assert.Nil(t, err)
+	assert.Equal(t, entry, item39)
 }

--- a/onChainStorage/onchain_storage.go
+++ b/onChainStorage/onchain_storage.go
@@ -8,12 +8,31 @@ import "github.com/ethereum/go-ethereum/common"
 type OnChainStorage interface {
 	Get(location common.Hash) (common.Hash, error)
 	Set(location, value common.Hash) error
+	Slot(location common.Hash) OnChainStorageSlot
+}
+
+type OnChainStorageSlot interface {
+	Get() (common.Hash, error)
+	Set(value common.Hash) error
 }
 
 type MockOnChainStorage struct {
 	contents   map[common.Hash]common.Hash
 	readCount  uint64
 	writeCount uint64
+}
+
+type MockOnChainStorageSlot struct {
+	sto      *MockOnChainStorage
+	location common.Hash
+}
+
+func (m *MockOnChainStorageSlot) Get() (common.Hash, error) {
+	return m.sto.Get(m.location)
+}
+
+func (m MockOnChainStorageSlot) Set(value common.Hash) error {
+	return m.sto.Set(m.location, value)
 }
 
 func NewMockOnChainStorage() OnChainStorage {
@@ -38,6 +57,13 @@ func (m *MockOnChainStorage) Set(location, value common.Hash) error {
 		m.contents[location] = value
 	}
 	return nil
+}
+
+func (m *MockOnChainStorage) Slot(location common.Hash) OnChainStorageSlot {
+	return &MockOnChainStorageSlot{
+		sto:      m,
+		location: location,
+	}
 }
 
 func (m *MockOnChainStorage) GetAccessCounts() (uint64, uint64) {

--- a/onChainStorage/onchain_storage.go
+++ b/onChainStorage/onchain_storage.go
@@ -6,8 +6,8 @@ package onChainStorage
 import "github.com/ethereum/go-ethereum/common"
 
 type OnChainStorage interface {
-	Read(location common.Hash) common.Hash
-	Write(location, value common.Hash)
+	Get(location common.Hash) (common.Hash, error)
+	Set(location, value common.Hash) error
 }
 
 type MockOnChainStorage struct {
@@ -20,23 +20,24 @@ func NewMockOnChainStorage() OnChainStorage {
 	return &MockOnChainStorage{contents: make(map[common.Hash]common.Hash)}
 }
 
-func (m *MockOnChainStorage) Read(location common.Hash) common.Hash {
+func (m *MockOnChainStorage) Get(location common.Hash) (common.Hash, error) {
 	m.readCount++
 	value, exists := m.contents[location]
 	if exists {
-		return value
+		return value, nil
 	} else {
-		return common.Hash{}
+		return common.Hash{}, nil
 	}
 }
 
-func (m *MockOnChainStorage) Write(location, value common.Hash) {
+func (m *MockOnChainStorage) Set(location, value common.Hash) error {
 	m.writeCount++
 	if value == (common.Hash{}) {
 		delete(m.contents, location)
 	} else {
 		m.contents[location] = value
 	}
+	return nil
 }
 
 func (m *MockOnChainStorage) GetAccessCounts() (uint64, uint64) {


### PR DESCRIPTION
This makes two general changes to make the on-chain index compatible with the Nitro stack.

First, it adds error returns to all operations that read and write on-chain storage. These are needed because real execution will return an error if storage access causes the current transaction to run out of gas. 

Second, this adds a notion of storage slots to the on-chain storage interface. This will allow the use of storage slot abstraction when using real Nitro storage, which is more efficient because it allows precomputation of the hashes used to multiplex the address space in ArbOS.